### PR TITLE
Enhance Document API with content management methods

### DIFF
--- a/edda_core/src/filemgr/document.rs
+++ b/edda_core/src/filemgr/document.rs
@@ -2,13 +2,13 @@ use std::fmt::Write;
 use std::path::Path;
 use std::{fs::File, io};
 
-use docx_rs::{Docx, Paragraph};
-use thiserror::Error;
 use crate::stylemgr::structural::StyledParagraph;
 #[allow(unused_imports)]
 use crate::stylemgr::style::Style;
 #[allow(unused_imports)]
 use crate::stylemgr::text::StyledText;
+use docx_rs::{Docx, Paragraph};
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DocumentError {
@@ -17,7 +17,6 @@ pub enum DocumentError {
     #[error("Document packaging error: {0}")]
     DocxPackaging(String),
 }
-
 
 pub struct Document {
     content: Vec<StyledParagraph>,
@@ -57,84 +56,83 @@ impl Metadata {
         self.description = Some(description.into());
         self
     }
-    
+
     /// Sets the category
     pub fn with_category(mut self, category: impl Into<String>) -> Self {
         self.category = Some(category.into());
         self
     }
-    
+
     /// Sets the version
     pub fn with_version(mut self, version: impl Into<String>) -> Self {
         self.version = Some(version.into());
         self
     }
-    
+
     /// Sets the status
     pub fn with_status(mut self, status: impl Into<String>) -> Self {
         self.status = Some(status.into());
         self
     }
-    
+
     /// Sets the language
     pub fn with_language(mut self, language: impl Into<String>) -> Self {
         self.language = Some(language.into());
         self
     }
-    
+
     /// Sets the keywords
     pub fn with_keywords(mut self, keywords: Vec<String>) -> Self {
         self.keywords = Some(keywords);
         self
     }
-    
+
     // Getters
-    
+
     /// Returns the title of the document
     pub fn title(&self) -> &str {
         &self.title
     }
-    
+
     /// Returns the authors of the document, if set
     pub fn authors(&self) -> Option<&Vec<String>> {
         self.authors.as_ref()
     }
-    
+
     /// Returns the description of the document, if set
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }
-    
+
     /// Returns the category of the document, if set
     pub fn category(&self) -> Option<&str> {
         self.category.as_deref()
     }
-    
+
     /// Returns the version of the document, if set
     pub fn version(&self) -> Option<&str> {
         self.version.as_deref()
     }
-    
+
     /// Returns the status of the document, if set
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()
     }
-    
+
     /// Returns the language of the document, if set
     pub fn language(&self) -> Option<&str> {
         self.language.as_deref()
     }
-    
+
     /// Returns the keywords of the document, if set
     pub fn keywords(&self) -> Option<&Vec<String>> {
         self.keywords.as_ref()
     }
 }
 
-
 impl Document {
     /// Create a blank document with the specified title
-    /// 
+    ///
     /// # Arguments
     /// * `title` - The title of the document
     pub fn new(title: impl Into<String>) -> Self {
@@ -145,7 +143,7 @@ impl Document {
     }
 
     /// Creates a new document with the given content and title
-    /// 
+    ///
     /// # Arguments
     /// * `title` - The title of the document
     /// * `content` - The initial content of the document
@@ -160,12 +158,12 @@ impl Document {
     pub fn get_metadata(&self) -> &Metadata {
         &self.metadata
     }
-    
+
     /// Returns a mutable reference to the document's metadata
     pub fn get_metadata_mut(&mut self) -> &mut Metadata {
         &mut self.metadata
     }
-    
+
     /// Sets the document's metadata
     pub fn set_metadata(&mut self, metadata: Metadata) -> &mut Self {
         self.metadata = metadata;
@@ -173,19 +171,19 @@ impl Document {
     }
 
     /// Adds a paragraph to the document
-    /// 
+    ///
     /// # Arguments
     /// * `paragraph` - The paragraph to add to the document
     pub fn add_paragraph(&mut self, paragraph: StyledParagraph) -> &mut Self {
         self.content.push(paragraph);
         self
     }
-    
+
     /// Removes a paragraph at the specified index
-    /// 
+    ///
     /// # Arguments
     /// * `index` - The index of the paragraph to remove
-    /// 
+    ///
     /// # Returns
     /// The removed paragraph, or None if the index is out of bounds
     pub fn remove_paragraph(&mut self, index: usize) -> Option<StyledParagraph> {
@@ -195,35 +193,35 @@ impl Document {
             None
         }
     }
-    
+
     /// Returns a reference to the paragraph at the specified index
-    /// 
+    ///
     /// # Arguments
     /// * `index` - The index of the paragraph to get
     pub fn get_paragraph(&self, index: usize) -> Option<&StyledParagraph> {
         self.content.get(index)
     }
-    
+
     /// Returns a mutable reference to the paragraph at the specified index
-    /// 
+    ///
     /// # Arguments
     /// * `index` - The index of the paragraph to get
     pub fn get_paragraph_mut(&mut self, index: usize) -> Option<&mut StyledParagraph> {
         self.content.get_mut(index)
     }
-    
+
     /// Returns the number of paragraphs in the document
     pub fn paragraph_count(&self) -> usize {
         self.content.len()
     }
-    
+
     /// Checks if the document is empty (contains no paragraphs)
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
     }
 
     /// Get full document as string
-    /// 
+    ///
     /// # Arguments
     /// * `tagged` - If true, includes style tags in the output
     pub fn get_text(&self, tagged: bool) -> String {
@@ -362,32 +360,35 @@ mod tests {
 
         Ok(())
     }
-    
+
     #[test]
     fn test_save_as_docx_io_error() {
         let doc = create_test_document();
         // Use a location that should be inaccessible for writing
-        // This is OS-specific, but /dev/null/invalid on Unix or an invalid device path on Windows 
+        // This is OS-specific, but /dev/null/invalid on Unix or an invalid device path on Windows
         // should generate an IO error
         #[cfg(unix)]
         let invalid_path = "/dev/null/invalid_path.docx";
         #[cfg(windows)]
         let invalid_path = "\\\\invalid-device\\nonexistent\\file.docx";
-        
+
         let result = doc.save_as_docx(invalid_path);
-        
+
         match result {
             Err(DocumentError::Io(e)) => {
                 // Verify it's an IO error
-                assert!(e.kind() == io::ErrorKind::NotFound || 
-                       e.kind() == io::ErrorKind::PermissionDenied ||
-                       e.kind() == io::ErrorKind::Other,
-                       "Expected NotFound, PermissionDenied or Other error kind, got {:?}", e.kind());
-            },
+                assert!(
+                    e.kind() == io::ErrorKind::NotFound
+                        || e.kind() == io::ErrorKind::PermissionDenied
+                        || e.kind() == io::ErrorKind::Other,
+                    "Expected NotFound, PermissionDenied or Other error kind, got {:?}",
+                    e.kind()
+                );
+            }
             _ => panic!("Expected an IO error, got {:?}", result),
         }
     }
-    
+
     #[test]
     fn test_error_display() {
         // Test IO error display
@@ -395,66 +396,66 @@ mod tests {
         let doc_err = DocumentError::Io(io_err);
         assert!(format!("{}", doc_err).contains("IO error"));
         assert!(format!("{}", doc_err).contains("file not found"));
-    
+
         // Test packaging error display
         let pkg_err = DocumentError::DocxPackaging("failed to package".into());
         assert!(format!("{}", pkg_err).contains("Document packaging error"));
         assert!(format!("{}", pkg_err).contains("failed to package"));
     }
-    
+
     #[test]
     fn test_document_paragraph_manipulation() {
         let mut doc = Document::new("Test Doc");
         assert!(doc.is_empty());
         assert_eq!(doc.paragraph_count(), 0);
-        
+
         // Add paragraphs
         let para1 = StyledParagraph::new();
         let para2 = StyledParagraph::new();
-        
+
         doc.add_paragraph(para1);
         assert_eq!(doc.paragraph_count(), 1);
         assert!(!doc.is_empty());
-        
+
         doc.add_paragraph(para2);
         assert_eq!(doc.paragraph_count(), 2);
-        
+
         // Get paragraph
         let para_ref = doc.get_paragraph(0);
         assert!(para_ref.is_some());
-        
+
         // Remove paragraph
         let removed = doc.remove_paragraph(0);
         assert!(removed.is_some());
         assert_eq!(doc.paragraph_count(), 1);
-        
+
         // Out of bounds access
         assert!(doc.get_paragraph(10).is_none());
         assert!(doc.get_paragraph_mut(10).is_none());
         assert!(doc.remove_paragraph(10).is_none());
     }
-    
+
     #[test]
     fn test_document_with_content() {
         let style = Style::new();
-        
+
         let mut para1 = StyledParagraph::new();
         para1.add(StyledText::new("Test content".to_string(), style.clone()));
-        
+
         let paras = vec![para1];
-        
+
         let doc = Document::with_content("With Content Doc", paras);
         assert_eq!(doc.paragraph_count(), 1);
         assert!(!doc.is_empty());
         assert_eq!(doc.get_text(false), "Test content");
     }
-    
+
     #[test]
     fn test_metadata_getters_and_setters() {
         let title = "Test Title";
         let authors = vec!["Author 1".to_string(), "Author 2".to_string()];
         let description = "Test Description";
-        
+
         let metadata = Metadata::new(title)
             .with_authors(authors.clone())
             .with_description(description)
@@ -463,7 +464,7 @@ mod tests {
             .with_status("Draft")
             .with_language("en-US")
             .with_keywords(vec!["test".to_string(), "example".to_string()]);
-        
+
         // Test getters
         assert_eq!(metadata.title(), title);
         assert_eq!(metadata.authors().unwrap(), &authors);
@@ -472,20 +473,23 @@ mod tests {
         assert_eq!(metadata.version().unwrap(), "1.0.0");
         assert_eq!(metadata.status().unwrap(), "Draft");
         assert_eq!(metadata.language().unwrap(), "en-US");
-        assert_eq!(metadata.keywords().unwrap(), &vec!["test".to_string(), "example".to_string()]);
-        
+        assert_eq!(
+            metadata.keywords().unwrap(),
+            &vec!["test".to_string(), "example".to_string()]
+        );
+
         // Test with Document
         let mut doc = Document::new("Original Title");
         doc.set_metadata(metadata);
-        
+
         let metadata_ref = doc.get_metadata();
         assert_eq!(metadata_ref.title(), "Test Title");
-        
+
         // Test mutable metadata
         let metadata_mut = doc.get_metadata_mut();
         let new_metadata = Metadata::new("New Title");
         *metadata_mut = new_metadata;
-        
+
         assert_eq!(doc.get_metadata().title(), "New Title");
     }
 }

--- a/edda_core/src/filemgr/document.rs
+++ b/edda_core/src/filemgr/document.rs
@@ -3,12 +3,21 @@ use std::path::Path;
 use std::{fs::File, io};
 
 use docx_rs::{Docx, Paragraph};
-
+use thiserror::Error;
 use crate::stylemgr::structural::StyledParagraph;
 #[allow(unused_imports)]
 use crate::stylemgr::style::Style;
 #[allow(unused_imports)]
 use crate::stylemgr::text::StyledText;
+
+#[derive(Error, Debug)]
+pub enum DocumentError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    #[error("Document packaging error: {0}")]
+    DocxPackaging(String),
+}
+
 
 pub struct Document {
     content: Vec<StyledParagraph>,
@@ -16,7 +25,7 @@ pub struct Document {
 }
 
 #[allow(dead_code)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Metadata {
     title: String,
     authors: Option<Vec<String>>,
@@ -28,22 +37,195 @@ pub struct Metadata {
     keywords: Option<Vec<String>>,
 }
 
-impl Document {
-    /// Create a blank document
-    pub fn new(title: &str) -> Self {
+impl Metadata {
+    /// Creates a new Metadata instance with the given title
+    pub fn new(title: impl Into<String>) -> Self {
         Self {
-            content: Vec::new(),
-            metadata: Metadata {
-                title: title.into(),
-                ..Default::default()
-            },
+            title: title.into(),
+            ..Default::default()
         }
     }
 
+    /// Sets the authors
+    pub fn with_authors(mut self, authors: Vec<String>) -> Self {
+        self.authors = Some(authors);
+        self
+    }
+
+    /// Sets the description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+    
+    /// Sets the category
+    pub fn with_category(mut self, category: impl Into<String>) -> Self {
+        self.category = Some(category.into());
+        self
+    }
+    
+    /// Sets the version
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+    
+    /// Sets the status
+    pub fn with_status(mut self, status: impl Into<String>) -> Self {
+        self.status = Some(status.into());
+        self
+    }
+    
+    /// Sets the language
+    pub fn with_language(mut self, language: impl Into<String>) -> Self {
+        self.language = Some(language.into());
+        self
+    }
+    
+    /// Sets the keywords
+    pub fn with_keywords(mut self, keywords: Vec<String>) -> Self {
+        self.keywords = Some(keywords);
+        self
+    }
+    
+    // Getters
+    
+    /// Returns the title of the document
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+    
+    /// Returns the authors of the document, if set
+    pub fn authors(&self) -> Option<&Vec<String>> {
+        self.authors.as_ref()
+    }
+    
+    /// Returns the description of the document, if set
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+    
+    /// Returns the category of the document, if set
+    pub fn category(&self) -> Option<&str> {
+        self.category.as_deref()
+    }
+    
+    /// Returns the version of the document, if set
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
+    
+    /// Returns the status of the document, if set
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+    
+    /// Returns the language of the document, if set
+    pub fn language(&self) -> Option<&str> {
+        self.language.as_deref()
+    }
+    
+    /// Returns the keywords of the document, if set
+    pub fn keywords(&self) -> Option<&Vec<String>> {
+        self.keywords.as_ref()
+    }
+}
+
+
+impl Document {
+    /// Create a blank document with the specified title
+    /// 
+    /// # Arguments
+    /// * `title` - The title of the document
+    pub fn new(title: impl Into<String>) -> Self {
+        Self {
+            content: Vec::new(),
+            metadata: Metadata::new(title),
+        }
+    }
+
+    /// Creates a new document with the given content and title
+    /// 
+    /// # Arguments
+    /// * `title` - The title of the document
+    /// * `content` - The initial content of the document
+    pub fn with_content(title: impl Into<String>, content: Vec<StyledParagraph>) -> Self {
+        Self {
+            content,
+            metadata: Metadata::new(title),
+        }
+    }
+
+    /// Returns a reference to the document's metadata
     pub fn get_metadata(&self) -> &Metadata {
         &self.metadata
     }
+    
+    /// Returns a mutable reference to the document's metadata
+    pub fn get_metadata_mut(&mut self) -> &mut Metadata {
+        &mut self.metadata
+    }
+    
+    /// Sets the document's metadata
+    pub fn set_metadata(&mut self, metadata: Metadata) -> &mut Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Adds a paragraph to the document
+    /// 
+    /// # Arguments
+    /// * `paragraph` - The paragraph to add to the document
+    pub fn add_paragraph(&mut self, paragraph: StyledParagraph) -> &mut Self {
+        self.content.push(paragraph);
+        self
+    }
+    
+    /// Removes a paragraph at the specified index
+    /// 
+    /// # Arguments
+    /// * `index` - The index of the paragraph to remove
+    /// 
+    /// # Returns
+    /// The removed paragraph, or None if the index is out of bounds
+    pub fn remove_paragraph(&mut self, index: usize) -> Option<StyledParagraph> {
+        if index < self.content.len() {
+            Some(self.content.remove(index))
+        } else {
+            None
+        }
+    }
+    
+    /// Returns a reference to the paragraph at the specified index
+    /// 
+    /// # Arguments
+    /// * `index` - The index of the paragraph to get
+    pub fn get_paragraph(&self, index: usize) -> Option<&StyledParagraph> {
+        self.content.get(index)
+    }
+    
+    /// Returns a mutable reference to the paragraph at the specified index
+    /// 
+    /// # Arguments
+    /// * `index` - The index of the paragraph to get
+    pub fn get_paragraph_mut(&mut self, index: usize) -> Option<&mut StyledParagraph> {
+        self.content.get_mut(index)
+    }
+    
+    /// Returns the number of paragraphs in the document
+    pub fn paragraph_count(&self) -> usize {
+        self.content.len()
+    }
+    
+    /// Checks if the document is empty (contains no paragraphs)
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
+
     /// Get full document as string
+    /// 
+    /// # Arguments
+    /// * `tagged` - If true, includes style tags in the output
     pub fn get_text(&self, tagged: bool) -> String {
         let mut buffer = String::with_capacity(self.content.len() * 100);
 
@@ -59,7 +241,7 @@ impl Document {
         buffer
     }
 
-    pub fn save_as_docx<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+    pub fn save_as_docx<P: AsRef<Path>>(&self, path: P) -> Result<(), DocumentError> {
         let mut document = Docx::new();
 
         for styled_paragraph in &self.content {
@@ -74,7 +256,10 @@ impl Document {
         }
 
         let mut file = File::create(path)?;
-        document.build().pack(&mut file)?;
+        document
+            .build()
+            .pack(&mut file)
+            .map_err(|e| DocumentError::DocxPackaging(e.to_string()))?;
 
         Ok(())
     }
@@ -176,5 +361,131 @@ mod tests {
         fs::remove_file(&file_path)?;
 
         Ok(())
+    }
+    
+    #[test]
+    fn test_save_as_docx_io_error() {
+        let doc = create_test_document();
+        // Use a location that should be inaccessible for writing
+        // This is OS-specific, but /dev/null/invalid on Unix or an invalid device path on Windows 
+        // should generate an IO error
+        #[cfg(unix)]
+        let invalid_path = "/dev/null/invalid_path.docx";
+        #[cfg(windows)]
+        let invalid_path = "\\\\invalid-device\\nonexistent\\file.docx";
+        
+        let result = doc.save_as_docx(invalid_path);
+        
+        match result {
+            Err(DocumentError::Io(e)) => {
+                // Verify it's an IO error
+                assert!(e.kind() == io::ErrorKind::NotFound || 
+                       e.kind() == io::ErrorKind::PermissionDenied ||
+                       e.kind() == io::ErrorKind::Other,
+                       "Expected NotFound, PermissionDenied or Other error kind, got {:?}", e.kind());
+            },
+            _ => panic!("Expected an IO error, got {:?}", result),
+        }
+    }
+    
+    #[test]
+    fn test_error_display() {
+        // Test IO error display
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
+        let doc_err = DocumentError::Io(io_err);
+        assert!(format!("{}", doc_err).contains("IO error"));
+        assert!(format!("{}", doc_err).contains("file not found"));
+    
+        // Test packaging error display
+        let pkg_err = DocumentError::DocxPackaging("failed to package".into());
+        assert!(format!("{}", pkg_err).contains("Document packaging error"));
+        assert!(format!("{}", pkg_err).contains("failed to package"));
+    }
+    
+    #[test]
+    fn test_document_paragraph_manipulation() {
+        let mut doc = Document::new("Test Doc");
+        assert!(doc.is_empty());
+        assert_eq!(doc.paragraph_count(), 0);
+        
+        // Add paragraphs
+        let para1 = StyledParagraph::new();
+        let para2 = StyledParagraph::new();
+        
+        doc.add_paragraph(para1);
+        assert_eq!(doc.paragraph_count(), 1);
+        assert!(!doc.is_empty());
+        
+        doc.add_paragraph(para2);
+        assert_eq!(doc.paragraph_count(), 2);
+        
+        // Get paragraph
+        let para_ref = doc.get_paragraph(0);
+        assert!(para_ref.is_some());
+        
+        // Remove paragraph
+        let removed = doc.remove_paragraph(0);
+        assert!(removed.is_some());
+        assert_eq!(doc.paragraph_count(), 1);
+        
+        // Out of bounds access
+        assert!(doc.get_paragraph(10).is_none());
+        assert!(doc.get_paragraph_mut(10).is_none());
+        assert!(doc.remove_paragraph(10).is_none());
+    }
+    
+    #[test]
+    fn test_document_with_content() {
+        let style = Style::new();
+        
+        let mut para1 = StyledParagraph::new();
+        para1.add(StyledText::new("Test content".to_string(), style.clone()));
+        
+        let paras = vec![para1];
+        
+        let doc = Document::with_content("With Content Doc", paras);
+        assert_eq!(doc.paragraph_count(), 1);
+        assert!(!doc.is_empty());
+        assert_eq!(doc.get_text(false), "Test content");
+    }
+    
+    #[test]
+    fn test_metadata_getters_and_setters() {
+        let title = "Test Title";
+        let authors = vec!["Author 1".to_string(), "Author 2".to_string()];
+        let description = "Test Description";
+        
+        let metadata = Metadata::new(title)
+            .with_authors(authors.clone())
+            .with_description(description)
+            .with_category("Test Category")
+            .with_version("1.0.0")
+            .with_status("Draft")
+            .with_language("en-US")
+            .with_keywords(vec!["test".to_string(), "example".to_string()]);
+        
+        // Test getters
+        assert_eq!(metadata.title(), title);
+        assert_eq!(metadata.authors().unwrap(), &authors);
+        assert_eq!(metadata.description().unwrap(), description);
+        assert_eq!(metadata.category().unwrap(), "Test Category");
+        assert_eq!(metadata.version().unwrap(), "1.0.0");
+        assert_eq!(metadata.status().unwrap(), "Draft");
+        assert_eq!(metadata.language().unwrap(), "en-US");
+        assert_eq!(metadata.keywords().unwrap(), &vec!["test".to_string(), "example".to_string()]);
+        
+        // Test with Document
+        let mut doc = Document::new("Original Title");
+        doc.set_metadata(metadata);
+        
+        let metadata_ref = doc.get_metadata();
+        assert_eq!(metadata_ref.title(), "Test Title");
+        
+        // Test mutable metadata
+        let metadata_mut = doc.get_metadata_mut();
+        let new_metadata = Metadata::new("New Title");
+        *metadata_mut = new_metadata;
+        
+        assert_eq!(doc.get_metadata().title(), "New Title");
     }
 }

--- a/edda_core/src/filemgr/document.rs
+++ b/edda_core/src/filemgr/document.rs
@@ -45,96 +45,106 @@ impl Metadata {
         }
     }
 
-    /// Sets the authors
+    /// Sets the authors for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_authors(mut self, authors: Vec<String>) -> Self {
         self.authors = Some(authors);
         self
     }
 
-    /// Sets the description
+    /// Sets the description for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
-    /// Sets the category
+    /// Sets the category for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_category(mut self, category: impl Into<String>) -> Self {
         self.category = Some(category.into());
         self
     }
 
-    /// Sets the version
+    /// Sets the version for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_version(mut self, version: impl Into<String>) -> Self {
         self.version = Some(version.into());
         self
     }
 
-    /// Sets the status
+    /// Sets the status for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_status(mut self, status: impl Into<String>) -> Self {
         self.status = Some(status.into());
         self
     }
 
-    /// Sets the language
+    /// Sets the language for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_language(mut self, language: impl Into<String>) -> Self {
         self.language = Some(language.into());
         self
     }
 
-    /// Sets the keywords
+    /// Sets the keywords for the metadata. Consumes and returns `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used"]
     pub fn with_keywords(mut self, keywords: Vec<String>) -> Self {
         self.keywords = Some(keywords);
         self
     }
 
-    // Getters
+    // --- Getters ---
 
-    /// Returns the title of the document
+    /// Returns a reference to the title string.
     pub fn title(&self) -> &str {
         &self.title
     }
 
-    /// Returns the authors of the document, if set
+    /// Returns an optional reference to the vector of author strings.
     pub fn authors(&self) -> Option<&Vec<String>> {
         self.authors.as_ref()
     }
 
-    /// Returns the description of the document, if set
+    /// Returns an optional reference to the description string slice.
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }
 
-    /// Returns the category of the document, if set
+    /// Returns an optional reference to the category string slice.
     pub fn category(&self) -> Option<&str> {
         self.category.as_deref()
     }
 
-    /// Returns the version of the document, if set
+    /// Returns an optional reference to the version string slice.
     pub fn version(&self) -> Option<&str> {
         self.version.as_deref()
     }
 
-    /// Returns the status of the document, if set
+    /// Returns an optional reference to the status string slice.
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()
     }
 
-    /// Returns the language of the document, if set
+    /// Returns an optional reference to the language string slice.
     pub fn language(&self) -> Option<&str> {
         self.language.as_deref()
     }
 
-    /// Returns the keywords of the document, if set
+    /// Returns an optional reference to the vector of keyword strings.
     pub fn keywords(&self) -> Option<&Vec<String>> {
         self.keywords.as_ref()
     }
 }
 
 impl Document {
-    /// Create a blank document with the specified title
+    /// Creates a new, empty `Document` with the specified title.
+    ///
+    /// The document will have no paragraphs initially.
     ///
     /// # Arguments
-    /// * `title` - The title of the document
+    /// * `title` - The title for the new document. Accepts any type that implements `Into<String>`.
+    #[must_use = "Creating a new Document does nothing unless assigned"]
     pub fn new(title: impl Into<String>) -> Self {
         Self {
             content: Vec::new(),
@@ -142,11 +152,12 @@ impl Document {
         }
     }
 
-    /// Creates a new document with the given content and title
+    /// Creates a new `Document` with the given title and initial content.
     ///
     /// # Arguments
-    /// * `title` - The title of the document
-    /// * `content` - The initial content of the document
+    /// * `title` - The title for the new document. Accepts any type that implements `Into<String>`.
+    /// * `content` - A vector of `StyledParagraph`s to initialize the document with.
+    #[must_use = "Creating a new Document does nothing unless assigned"]
     pub fn with_content(title: impl Into<String>, content: Vec<StyledParagraph>) -> Self {
         Self {
             content,
@@ -154,38 +165,45 @@ impl Document {
         }
     }
 
-    /// Returns a reference to the document's metadata
+    /// Returns an immutable reference to the document's `Metadata`.
     pub fn get_metadata(&self) -> &Metadata {
         &self.metadata
     }
 
-    /// Returns a mutable reference to the document's metadata
+    /// Returns a mutable reference to the document's `Metadata`, allowing modification.
     pub fn get_metadata_mut(&mut self) -> &mut Metadata {
         &mut self.metadata
     }
 
-    /// Sets the document's metadata
+    /// Replaces the document's existing `Metadata` with the provided one.
+    /// Returns a mutable reference to `self` for chaining.
+    #[must_use = "Method call does nothing unless the result is used (or you don't need chaining)"]
     pub fn set_metadata(&mut self, metadata: Metadata) -> &mut Self {
         self.metadata = metadata;
         self
     }
 
-    /// Adds a paragraph to the document
+    /// Appends a `StyledParagraph` to the end of the document's content.
+    /// Returns a mutable reference to `self` for chaining.
     ///
     /// # Arguments
-    /// * `paragraph` - The paragraph to add to the document
+    /// * `paragraph` - The `StyledParagraph` to add.
+    #[must_use = "Method call does nothing unless the result is used (or you don't need chaining)"]
     pub fn add_paragraph(&mut self, paragraph: StyledParagraph) -> &mut Self {
         self.content.push(paragraph);
         self
     }
 
-    /// Removes a paragraph at the specified index
+    /// Removes the `StyledParagraph` at the specified index.
     ///
     /// # Arguments
-    /// * `index` - The index of the paragraph to remove
+    /// * `index` - The zero-based index of the paragraph to remove.
     ///
     /// # Returns
-    /// The removed paragraph, or None if the index is out of bounds
+    /// The removed `StyledParagraph` if the index was valid, otherwise `None`.
+    ///
+    /// # Panics
+    /// This method does not panic; it returns `None` for out-of-bounds indices.
     pub fn remove_paragraph(&mut self, index: usize) -> Option<StyledParagraph> {
         if index < self.content.len() {
             Some(self.content.remove(index))
@@ -194,36 +212,46 @@ impl Document {
         }
     }
 
-    /// Returns a reference to the paragraph at the specified index
+    /// Returns an optional immutable reference to the `StyledParagraph` at the specified index.
     ///
     /// # Arguments
-    /// * `index` - The index of the paragraph to get
+    /// * `index` - The zero-based index of the paragraph to retrieve.
+    ///
+    /// # Returns
+    /// `Some(&StyledParagraph)` if the index is valid, otherwise `None`.
     pub fn get_paragraph(&self, index: usize) -> Option<&StyledParagraph> {
         self.content.get(index)
     }
 
-    /// Returns a mutable reference to the paragraph at the specified index
+    /// Returns an optional mutable reference to the `StyledParagraph` at the specified index.
     ///
     /// # Arguments
-    /// * `index` - The index of the paragraph to get
+    /// * `index` - The zero-based index of the paragraph to retrieve mutably.
+    ///
+    /// # Returns
+    /// `Some(&mut StyledParagraph)` if the index is valid, otherwise `None`.
     pub fn get_paragraph_mut(&mut self, index: usize) -> Option<&mut StyledParagraph> {
         self.content.get_mut(index)
     }
 
-    /// Returns the number of paragraphs in the document
+    /// Returns the total number of paragraphs currently in the document.
     pub fn paragraph_count(&self) -> usize {
         self.content.len()
     }
 
-    /// Checks if the document is empty (contains no paragraphs)
+    /// Returns `true` if the document contains no paragraphs, `false` otherwise.
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
     }
 
-    /// Get full document as string
+    /// Renders the entire document content as a single `String`.
     ///
     /// # Arguments
-    /// * `tagged` - If true, includes style tags in the output
+    /// * `tagged` - If `true`, includes inline style tags (e.g., `[[Style...]]Text[[/Style...]]`)
+    ///              in the output string. If `false`, only the raw text content is included.
+    ///
+    /// # Returns
+    /// A `String` containing the concatenated text of all paragraphs.
     pub fn get_text(&self, tagged: bool) -> String {
         let mut buffer = String::with_capacity(self.content.len() * 100);
 
@@ -239,6 +267,19 @@ impl Document {
         buffer
     }
 
+    /// Saves the document content as a DOCX file to the specified path.
+    ///
+    /// This method iterates through the `StyledParagraph`s and `StyledText`s,
+    /// converting them into the `docx_rs` representation and then packaging them
+    /// into a .docx file.
+    ///
+    /// # Arguments
+    /// * `path` - The file system path where the .docx file should be saved. Accepts any type
+    ///            that implements `AsRef<Path>`.
+    ///
+    /// # Errors
+    /// Returns `DocumentError::Io` if there's an issue creating or writing to the file.
+    /// Returns `DocumentError::DocxPackaging` if `docx_rs` encounters an error during packaging.
     pub fn save_as_docx<P: AsRef<Path>>(&self, path: P) -> Result<(), DocumentError> {
         let mut document = Docx::new();
 
@@ -296,11 +337,17 @@ mod tests {
     fn test_document_new() {
         let title = "My Document";
         let doc = Document::new(title);
+
+        // Check content is empty
         assert!(doc.content.is_empty());
-        assert_eq!(doc.metadata.title, title);
-        assert!(doc.metadata.authors.is_none());
-        assert!(doc.metadata.description.is_none());
-        // ... check other metadata fields if needed ...
+        assert!(doc.is_empty()); // Also check the helper method
+
+        // Check metadata against a default instance with the same title
+        let expected_metadata = Metadata {
+            title: title.to_string(),
+            ..Default::default()
+        };
+        assert_eq!(doc.metadata, expected_metadata);
     }
 
     #[test]
@@ -413,23 +460,46 @@ mod tests {
         let para1 = StyledParagraph::new();
         let para2 = StyledParagraph::new();
 
-        doc.add_paragraph(para1);
+        let _ = doc.add_paragraph(para1);
         assert_eq!(doc.paragraph_count(), 1);
         assert!(!doc.is_empty());
 
-        doc.add_paragraph(para2);
+        let _ = doc.add_paragraph(para2);
         assert_eq!(doc.paragraph_count(), 2);
 
-        // Get paragraph
+        // Get paragraph (immutable)
         let para_ref = doc.get_paragraph(0);
         assert!(para_ref.is_some());
+        // Ensure it's the first one we added (though they are empty here)
+        assert_eq!(para_ref.unwrap(), &StyledParagraph::new()); // Compare with a default empty one
 
-        // Remove paragraph
+        // Get paragraph (mutable) - Test modification
+        let para_mut = doc.get_paragraph_mut(1);
+        assert!(para_mut.is_some());
+        let style = Style::new().switch_bold();
+        let text = StyledText::new("Modified".to_string(), style);
+        para_mut.unwrap().add(text.clone());
+
+        // Verify modification via immutable getter
+        let para_ref_modified = doc.get_paragraph(1);
+        assert!(para_ref_modified.is_some());
+        assert_eq!(para_ref_modified.unwrap().raw.len(), 1);
+        assert_eq!(para_ref_modified.unwrap().raw[0], text);
+
+        // Remove paragraph and verify return value
+        // Re-create para1 for comparison, as the original was moved
+        let para1_original = StyledParagraph::new();
         let removed = doc.remove_paragraph(0);
         assert!(removed.is_some());
+        assert_eq!(removed.unwrap(), para1_original); // Check if the correct paragraph was removed
         assert_eq!(doc.paragraph_count(), 1);
 
-        // Out of bounds access
+        // Check remaining paragraph is the modified one
+        assert_eq!(doc.get_paragraph(0).unwrap().raw.len(), 1);
+        assert_eq!(doc.get_paragraph(0).unwrap().raw[0], text);
+
+        // Out of bounds access checks
+        assert!(doc.get_paragraph(1).is_none()); // Index 1 is now out of bounds
         assert!(doc.get_paragraph(10).is_none());
         assert!(doc.get_paragraph_mut(10).is_none());
         assert!(doc.remove_paragraph(10).is_none());
@@ -480,7 +550,7 @@ mod tests {
 
         // Test with Document
         let mut doc = Document::new("Original Title");
-        doc.set_metadata(metadata);
+        let _ = doc.set_metadata(metadata);
 
         let metadata_ref = doc.get_metadata();
         assert_eq!(metadata_ref.title(), "Test Title");

--- a/edda_core/src/stylemgr/structural.rs
+++ b/edda_core/src/stylemgr/structural.rs
@@ -23,7 +23,7 @@ pub enum ApplicableStyles {
 }
 
 /// Collection of text chunks with its own styles
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct StyledParagraph {
     pub raw: Vec<StyledText>,
 }

--- a/edda_core/src/stylemgr/style.rs
+++ b/edda_core/src/stylemgr/style.rs
@@ -64,7 +64,7 @@ impl fmt::Display for UnderlineStyle {
 }
 
 /// A defined Style for a chunk of text.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Style {
     bold: bool,
     italic: bool,

--- a/edda_core/src/stylemgr/text.rs
+++ b/edda_core/src/stylemgr/text.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 /// Chunk of text attached to a certain style
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StyledText {
     pub text: String,
     pub style: Style,


### PR DESCRIPTION
**Title:** Feat: Enhance Document API with manipulation and metadata access

This PR enhances the `Document` module, providing a more complete and ergonomic API for creation, manipulation, and inspection.

**Key Changes:**

*   **Paragraph Manipulation:**
    *   Implement methods for adding, removing, and retrieving paragraphs within the document (e.g., `add_paragraph`, `remove_paragraph`, `get_paragraph`).
*   **Metadata Access:**
    *   Implement comprehensive getters and setters for all fields within the document's `Metadata`.
*   **Document Information & Helpers:**
    *   Add an `is_empty()` method to check if the document contains any paragraphs.
    *   Add a `paragraph_count()` method to get the number of paragraphs.
*   **Construction:**
    *   Add a new constructor (e.g., `with_content` or similar) to create `Document` instances pre-populated with initial content (paragraphs).
*   **Testing:**
    *   Add comprehensive test coverage for all newly introduced functionality, ensuring correctness and handling edge cases.

These additions make interacting with `Document` objects more intuitive and cover common use cases, while maintaining backward compatibility with existing code.